### PR TITLE
Simplify the generated files, move testthat functionnality in external script

### DIFF
--- a/R/generate.R
+++ b/R/generate.R
@@ -85,7 +85,7 @@ generate_test.genthat_trace <- function(trace, include_trace_dump=FALSE, format_
 
 
         code <- paste0(
-            'genthat_extracted_function <- function() {\n',
+            'genthat_extracted_call <- function() {\n',
                 globals,
                 if (nchar(globals) > 0) '\n' else '',
                 call,'\n',
@@ -138,12 +138,6 @@ save_test <- function(pkg, fun, code, output_dir) {
     stopifnot(dir.exists(dname) || dir.create(dname, recursive=TRUE))
 
     fname <- next_file_in_row(file.path(dname, "test.R"))
-
-    externals <- attr(code, "externals")
-    if (length(externals) > 0) {
-        fname_ext <- paste0(tools::file_path_sans_ext(fname), ".ext")
-        saveRDS(externals, fname_ext)
-    }
 
     write(paste(code, collapse="\n\n"), file=fname)
 

--- a/R/genthat.R
+++ b/R/genthat.R
@@ -217,6 +217,14 @@ gen_from_package <- function(pkgs_to_trace, pkgs_to_run=pkgs_to_trace,
             }
         }
 
+        # Record the return value of runnable tests
+        lapply(result$output,
+            function(Rfile) {
+                extfile <- gsub(".R$", ".ext", Rfile)
+                try(record_test_exts(Rfile, extfile))
+            }
+        )
+
         attr(result, "errors") <- errors
         attr(result, "stats") <- c(
             "all"=nrow(tracing),
@@ -371,6 +379,7 @@ generate_action <- function(trace, output_dir, keep_failed_trace=FALSE) {
     tryCatch({
         testfile <- generate_test_file(trace, output_dir)
         log_debug("Saving test into: ", testfile)
+
         error <- NA
 
         if (getOption("genthat.keep_all_traces", FALSE)) {

--- a/R/record-test-exts.R
+++ b/R/record-test-exts.R
@@ -1,0 +1,28 @@
+
+# Run the generated unit test in a new R process with a known seed
+# to record the return value of a reproducible run
+
+run_test_in_isolation <- function(test, seed) {
+    callr::r(
+        function(test, seed) {
+            .Random.seed <<- seed
+            source(test)
+            genthat_extracted_call()
+        },
+        args=list(test=test, seed=seed)
+    )
+}
+
+record_test_exts <- function(test, extfile, seed=NULL) {
+    if (is.null(seed)) {
+        set.seed(NULL)
+        seed <- .Random.seed
+    }
+
+    exts <- list(
+        .ext.retv = run_test_in_isolation(test, seed),
+        .ext.seed = seed
+    )
+
+    saveRDS(exts, file=extfile)
+}

--- a/R/run-generated-tests.R
+++ b/R/run-generated-tests.R
@@ -10,7 +10,8 @@ test_generated_file <- function(test) {
         testthat::test_env()
     }
 
-    testthat::test_file(test, reporter="stop", wrap=FALSE, env=env)
+    capture.output(r <- { source(test, local=env); env$genthat_extracted_function() })
+    r
 }
 
 #' @export
@@ -29,10 +30,6 @@ run_generated_test <- function(tests, quiet=TRUE) {
             }
 
             time <- stopwatch(res <- test_generated_file(test))
-
-            if (length(res) == 0) {
-                stop("testthat::test_file result was empty")
-            }
 
             time <- as.numeric(time, units="secs")
 

--- a/R/run-generated-tests.R
+++ b/R/run-generated-tests.R
@@ -10,7 +10,7 @@ test_generated_file <- function(test) {
         testthat::test_env()
     }
 
-    capture.output(r <- { source(test, local=env); env$genthat_extracted_function() })
+    capture.output(r <- { source(test, local=env); env$genthat_extracted_call() })
     r
 }
 

--- a/tools/harnesses/benchmark.R
+++ b/tools/harnesses/benchmark.R
@@ -1,0 +1,75 @@
+#!/usr/bin/env Rscript
+
+verifyResult <- function(res, expected_retv) {
+	isTRUE(all.equal(res, expected_retv))
+}
+
+doRuns <- function(name, iterations, innerIterations, params) {
+    total <- 0
+    for (i in 1:iterations) {
+
+        results <- vector(mode = "list", length = innerIterations)
+
+        startTime <- Sys.time()
+        for (k in 1:innerIterations) {
+          .Random.seed <<- params$.ext.seed
+          # wrap the result in a list to prevent NULL assignments
+          # from removing a cell from the vector
+          results[[k]] <- list(genthat_extracted_call())
+        }
+        endTime <- Sys.time()
+
+        for (k in 1:innerIterations) {
+          if (!verifyResult(results[[k]], list(params$.ext.retv))) {
+              message("Benchmark failed: incorrect result")
+              message("res=\n", results[[k]], "\n\nexpected=\n", list(params$retv))
+              stop("Benchmark failed")
+          }
+        }
+
+        runTime <- (as.numeric(endTime) - as.numeric(startTime)) * 1000000
+
+        cat(name, ": iterations=1 runtime: ", round(runTime), "us\n", sep = "")
+        total <- total + runTime
+    }
+    total
+}
+
+run <- function(args) {
+    if (length(args) < 2 || 3 < length(args))
+        stop(printUsage())
+
+    name <- args[[1]]
+    numIterations <- strtoi(args[[2]])
+
+
+    innerIterations <- 1
+    if (length(args) >= 3)
+      innerIterations <- strtoi(args[[3]])
+
+    Rfile <- normalizePath(paste0(name, ".R"))
+    extfile <- normalizePath(paste0(name, ".ext"))
+
+		params <- readRDS(extfile)
+    .Random.seed <<- params$.ext.seed
+    source(Rfile)
+    
+    total <- as.numeric(doRuns(name, numIterations, innerIterations, params));
+    cat(name, ": ",
+        "iterations=", numIterations, "; ",
+        "average: ", round(total / numIterations), " us; ",
+        "total: ", round(total), "us\n\n", sep="")
+    #cat("Total runtime: ", total, "us\n\n", sep="")
+}
+
+printUsage <- function() {
+    cat("harness.r benchmark num-iterations [inner-iterations]\n")
+    cat("\n")
+    cat("  benchmark           - benchmark class name (filename without the extension)\n")
+    cat("  num-iterations      - number of times to execute benchmark\n")
+    cat("  inner-iterations    - number of times the benchmark is executed in an inner loop,\n")
+    cat("                        which is measured in total, default: 1\n")
+
+}
+
+run(commandArgs(trailingOnly=TRUE))

--- a/tools/harnesses/test_files.R
+++ b/tools/harnesses/test_files.R
@@ -1,0 +1,57 @@
+#!/usr/bin/env Rscript
+
+# Run this file either as a script:
+#
+#    (bash)
+#    $ GENERATED_TESTS_DIR="./tests" ./test_files.R
+#    $ ./test_files.R ./tests/yaml/as.yaml/test-36.R ./tests/yaml/yaml.load/test-57.R
+#
+# or with testthat::test_file()
+#
+#    (R)
+#    > withr::with_envvar(
+#          list(GENERATED_TESTS_DIR="./tests"),
+#          testthat::test_file("./test_files.R")
+#      )
+
+GENERATED_TESTS_DIR=Sys.getenv("GENERATED_TESTS_DIR", unset=NA)
+
+run_file <- function(Rfile, seed) {
+    .Random.seed <<- seed
+    source(Rfile)
+
+    .Random.seed <<- seed
+    genthat_extracted_call()
+}
+
+
+test_file <- function(Rfile) {
+    extfile <- gsub(".R$", ".ext", Rfile)
+		params <- readRDS(extfile)
+    testthat::test_that(Rfile, testthat::expect_equal(run_file(Rfile, params$.ext.seed), params$.ext.retv))
+}
+
+
+run <- function(args) {
+    Rfiles <- list()
+
+    if (length(args) >= 1 ) {
+      Rfiles <- args
+    } else if (! is.na(GENERATED_TESTS_DIR)) {
+      Rfiles <- list.files(GENERATED_TESTS_DIR, recursive=TRUE, pattern="\\.R$", full.names=TRUE)
+    } else {
+      printUsage()
+      stop("No arguments and GENERATED_TESTS_DIR is unset.")
+    }
+
+    invisible(lapply(Rfiles, test_file))
+}
+
+printUsage <- function() {
+  message("test_files.R [test1.R test2.R test3.R ...]")
+  message(" testk.R     - the files to test. Should be accompanied by a corresponding testk.ext file.")
+  message("               If no files are specified, all the files in the GENERATED_TESTS_DIR directory are run")
+  message("")
+}
+
+run(commandArgs(trailingOnly=TRUE))


### PR DESCRIPTION
After this PR, the generated files are much simpler. Here is for instance `yaml/as.yaml/test-36.R`:

```R
genthat_extracted_call <- function() {
    yaml:::as.yaml(x = 0)
}
```

The return value and the seed are recorded in the `.ext` file (with the function `record_test_exts`) after the generation of the file ; this way the files can be run in isolation (using `callr`).

This makes it possible to still use the generated files as unit tests using testthat, but also to use them for other uses like benchmarks. These functionalities are taken care of by external scripts. This approach has the advantage that it easier to add new functionalities without having to re-generate all the files.

For instance, the files  `benchmark.R` and `test_file.R` (in `tools/harnesses/`) implement the previously mentioned functionalities:

```console
# with the tests generated in ./tests

# Test one file
$ "/path/to/harnesses/test_files.R" "tests/yaml/as.yaml/test-36.R"
Test passed 🎉

# Test all the files in "tests"
$ GENERATED_TESTS_DIR="./tests"  "/path/to/harnesses/test_files.R"
Test passed 🎉
Test passed 😀
Test passed 🥳

# From R with test_file (pass environment variable to R, or use withr::with_envvar)
$ GENERATED_TESTS_DIR="/path/to/tests" R
> testthat::test_file("/path/to/harnesses/test_files.R")
══ Testing test_files.R ═════════════════════════════════════════════════════════
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 3 ] Done!

# Benchmark the test (the output format is compatible with [ReBench](https://rebench.readthedocs.io))
$ benchmark.R tests/yaml/as.yaml/test-36 5 100
tests/yaml/as.yaml/test-36: iterations=1 runtime: 3876us
tests/yaml/as.yaml/test-36: iterations=1 runtime: 1234us
tests/yaml/as.yaml/test-36: iterations=1 runtime: 1222us
tests/yaml/as.yaml/test-36: iterations=1 runtime: 1226us
tests/yaml/as.yaml/test-36: iterations=1 runtime: 1189us
tests/yaml/as.yaml/test-36: iterations=5; average: 1749 us; total: 8747us

```
